### PR TITLE
Fix Maven Central publishing: invalid version from unoverridable GITHUB_REF

### DIFF
--- a/.github/workflows/pdfium-auto-release.yaml
+++ b/.github/workflows/pdfium-auto-release.yaml
@@ -170,6 +170,16 @@ jobs:
           git tag "$tag"
           git push origin "$tag"
 
+      - name: Create GitHub release
+        # Tags pushed with GITHUB_TOKEN don't trigger other workflows (including
+        # release-graalvm.yaml), so the release must be created here explicitly.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="v${{ needs.detect.outputs.full_version }}"
+          gh release create "$tag" --title "$tag" --generate-notes
+
       - name: Delete bump branch
         run: git push origin --delete "${{ needs.detect.outputs.branch }}" || true
 

--- a/.github/workflows/pdfium-auto-release.yaml
+++ b/.github/workflows/pdfium-auto-release.yaml
@@ -211,15 +211,18 @@ jobs:
         uses: gradle/actions/setup-gradle@v5
 
       - name: Publish to Maven Central
-        # GITHUB_REF override drives pdfium/build.gradle.kts publishVersion (reads
-        # GITHUB_REF and strips refs/tags/v). The tag was pushed by GITHUB_TOKEN
-        # so publish-maven.yaml will not fire — publishing inline avoids the
-        # recursive-trigger gap and keeps everything in one run.
+        # -PpublishVersion drives pdfium/build.gradle.kts publishVersion — the GITHUB_REF
+        # default variable cannot be overridden via `env:` (the runner re-applies it), which
+        # silently produced an invalid 'refs/heads/master' version and broke every inline
+        # publish. The tag was pushed by GITHUB_TOKEN so publish-maven.yaml will not fire —
+        # publishing inline avoids the recursive-trigger gap and keeps everything in one run.
         env:
-          GITHUB_REF: refs/tags/v${{ needs.detect.outputs.full_version }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVENCENTRALUSERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVENCENTRALPASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNINGINMEMORYKEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNINGKEYID }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNINGPASSWORD }}
-        run: ./gradlew :pdfium:publishAndReleaseToMavenCentral --no-configuration-cache
+        run: >
+          ./gradlew :pdfium:publishAndReleaseToMavenCentral
+          -PpublishVersion=${{ needs.detect.outputs.full_version }}
+          --no-configuration-cache

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Published to Maven Central. Requires Gradle 8.10+ and Kotlin 2.3.20+. The
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("dev.nucleusframework:pdfium:149.0.7802.0b")
+            implementation("dev.nucleusframework:pdfium:152.0.7934.0b")
         }
     }
 }

--- a/pdfium/build.gradle.kts
+++ b/pdfium/build.gradle.kts
@@ -26,10 +26,16 @@ plugins {
     alias(libs.plugins.vanniktechMavenPublish)
 }
 
+// Explicit -PpublishVersion wins (used by the auto-release inline publish, where the
+// GITHUB_REF default variable cannot be overridden). Otherwise derive from a release
+// tag ref; non-tag refs (refs/heads/…) fall back to the dev version instead of
+// producing an invalid version containing '/'.
 val publishVersion: String =
-    providers.environmentVariable("GITHUB_REF")
-        .orNull
-        ?.removePrefix("refs/tags/v")
+    providers.gradleProperty("publishVersion").orNull
+        ?: providers.environmentVariable("GITHUB_REF")
+            .orNull
+            ?.takeIf { it.startsWith("refs/tags/v") }
+            ?.removePrefix("refs/tags/v")
         ?: "0.1.0"
 
 group = "dev.nucleusframework"


### PR DESCRIPTION
## Context

`gradle/libs.versions.toml` is already pinned to the latest upstream PDFium (`chromium/7934` / 152.0.7934.0) — the nightly auto-release bumped it on July 7. But **nothing after 150.0.7857.0 ever reached Maven Central**: tags `v150.0.7869.0` → `v152.0.7934.0` exist, master was fast-forwarded, yet Central still serves 150.0.7857.0 as latest.

## Root cause

The auto-release `publish` job sets `GITHUB_REF: refs/tags/v…` in the step `env:` to drive `publishVersion` in `pdfium/build.gradle.kts`. GitHub Actions re-applies default variables after user `env:`, so the override never takes effect: Gradle sees `refs/heads/master` (schedule event), `removePrefix("refs/tags/v")` is a no-op, and publishing fails with:

```
Execution failed for task ':pdfium:publishAndroidReleasePublicationToMavenCentralRepository'.
> Invalid publication 'androidRelease': version cannot contain '/'.
```

(see run 28847340961, July 7). The tag is pushed *before* the publish step, so every failed run still leaves a release tag behind — which the guard then refuses to reuse.

## Fix

- `pdfium/build.gradle.kts`: `-PpublishVersion` gradle property takes precedence; the `GITHUB_REF` fallback now only accepts actual `refs/tags/v*` refs instead of silently producing an invalid version.
- `pdfium-auto-release.yaml`: pass `-PpublishVersion=<full_version>` to the publish invocation instead of the ineffective `GITHUB_REF` env override.
- README: dependency snippet bumped to `152.0.7934.0b` (the next release, see below).

The tag-push path (`publish-maven.yaml`) is unaffected — there `GITHUB_REF` genuinely is the tag ref.

## Release plan

`v152.0.7934.0` already exists as a git tag (from the failed July 7 run), so per the established convention the recovery release is **`v152.0.7934.0b`**, tagged on master after this merge. It ships PDFium 152.0.7934.0 **plus the clickable-links feature from #9**, and `publish-maven.yaml` rebuilds all JNI natives (including macOS/Windows) as part of the run.

## Test plan

- [x] Version resolution verified locally for all four cases: no input → `0.1.0`, `-PpublishVersion=152.0.7934.0b` → `152.0.7934.0b`, `GITHUB_REF=refs/tags/v152.0.7934.0b` → `152.0.7934.0b`, `GITHUB_REF=refs/heads/master` → `0.1.0` (previously `refs/heads/master`)
- [ ] `v152.0.7934.0b` tag push publishes to Maven Central via CI
- [ ] Next nightly auto-release publishes inline without manual intervention