### PR TITLE
fix(pdfium): don't double-free the buffer when PDFium refuses a document

### DIFF
--- a/pdfium/build.gradle.kts
+++ b/pdfium/build.gradle.kts
@@ -152,6 +152,7 @@ kotlin {
         // kotlinx-browser exposes the org.khronos.webgl.* typed arrays as a shared API
         // across js + wasmJs, so they resolve in the webMain metadata compilation.
         webMain.dependencies { implementation(libs.kotlinx.browser) }
+        jvmTest.dependencies { implementation(libs.kotlin.test) }
     }
 }
 

--- a/pdfium/src/androidMain/kotlin/dev/nucleusframework/pdfium/PdfDocument.android.kt
+++ b/pdfium/src/androidMain/kotlin/dev/nucleusframework/pdfium/PdfDocument.android.kt
@@ -199,8 +199,9 @@ internal actual suspend fun openPdfDocument(bytes: ByteArray, password: String?)
             for (i in 0 until POOL_SIZE) {
                 val h = PdfiumBridge.nOpenDocumentFromMemory(bufferAddr, bytes.size.toLong(), password)
                 if (h == 0L) {
+                    // NOTE: the buffer is freed by the catch below — freeing it here too
+                    // double-frees it (native abort, not an exception).
                     for (j in 0 until i) PdfiumBridge.nCloseDocument(handles[j])
-                    PdfiumBridge.nFreeBuffer(bufferAddr)
                     error("PDFium refused to open document (err=${PdfiumBridge.nGetLastError()})")
                 }
                 handles[i] = h

--- a/pdfium/src/jvmMain/kotlin/dev/nucleusframework/pdfium/PdfDocument.jvm.kt
+++ b/pdfium/src/jvmMain/kotlin/dev/nucleusframework/pdfium/PdfDocument.jvm.kt
@@ -224,9 +224,9 @@ internal actual suspend fun openPdfDocument(bytes: ByteArray, password: String?)
             for (i in 0 until POOL_SIZE) {
                 val h = PdfiumBridge.nOpenDocumentFromMemory(bufferAddr, bytes.size.toLong(), password)
                 if (h == 0L) {
-                    // Cleanup previously opened handles + buffer on failure.
+                    // Cleanup previously opened handles. The buffer is freed by the catch
+                    // below — freeing it here too double-frees it (native abort).
                     for (j in 0 until i) PdfiumBridge.nCloseDocument(handles[j])
-                    PdfiumBridge.nFreeBuffer(bufferAddr)
                     error("PDFium refused to open document (err=${PdfiumBridge.nGetLastError()})")
                 }
                 handles[i] = h

--- a/pdfium/src/jvmTest/kotlin/dev/nucleusframework/pdfium/OpenPdfDocumentTest.kt
+++ b/pdfium/src/jvmTest/kotlin/dev/nucleusframework/pdfium/OpenPdfDocumentTest.kt
@@ -1,0 +1,52 @@
+package dev.nucleusframework.pdfium
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.runBlocking
+
+class OpenPdfDocumentTest {
+    /**
+     * Regression: bytes PDFium refuses must surface as an exception, not kill the
+     * process. The open-failure branch used to free the native buffer that the
+     * enclosing `catch` frees as well, so a non-PDF body double-freed it and the
+     * host aborted — SIGABRT on the JVM, "Scudo ERROR: invalid chunk state when
+     * deallocating" on Android. Reaching the assertion at all IS the test.
+     */
+    @Test
+    fun refusedBytesThrowInsteadOfAbortingTheProcess() = runBlocking {
+        assertFailsWith<IllegalStateException> {
+            openPdfDocument("definitely not a pdf".encodeToByteArray(), null)
+        }
+        Unit
+    }
+
+    @Test
+    fun aValidDocumentStillOpens() = runBlocking {
+        val doc = openPdfDocument(minimalPdf(), null)
+        try {
+            kotlin.test.assertEquals(1, doc.pageCount)
+        } finally {
+            doc.close()
+        }
+    }
+}
+
+/** A minimal, valid one-page PDF (built-in /Helvetica, no embedded font program). */
+private fun minimalPdf(): ByteArray = java.util.Base64.getDecoder().decode(
+    "JVBERi0xLjQKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgPj4KZW5kb2Jq" +
+        "CjIgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzIC9LaWRzIFszIDAgUl0gL0NvdW50IDEgPj4KZW5kb2Jq" +
+        "CjMgMCBvYmoKPDwgL1R5cGUgL1BhZ2UgL1BhcmVudCAyIDAgUiAvTWVkaWFCb3ggWzAgMCA2MTIg" +
+        "NzkyXSAvQ29udGVudHMgNCAwIFIgL1Jlc291cmNlcyA8PCAvRm9udCA8PCAvRjEgNSAwIFIgPj4g" +
+        "Pj4gPj4KZW5kb2JqCjQgMCBvYmoKPDwgL0xlbmd0aCAzMzEgPj4Kc3RyZWFtCkJUIC9GMSAyNCBU" +
+        "ZiA3MiA3MDAgVGQgMjggVEwgKFRoZSBxdWljayBicm93biBmb3gganVtcHMgb3ZlciB0aGUgbGF6" +
+        "eSBkb2cuKSBUaiBUKiAoSW52b2ljZSAjMjAyNi0wNzE0ICBBbW91bnQgZHVlOiAkMSwyMzQuNTYp" +
+        "IFRqIFQqIChUaGlzIGlzIGEgdGV4dC1vbmx5IFBERiB0byBleGVyY2lzZSBwZGZpdW0gYXN5bmMg" +
+        "Z2x5cGggcGFpbnQuKSBUaiBUKiAoTGluZSBmb3VyIHdpdGggbW9yZSB3b3JkcyB0byBmaWxsIHRo" +
+        "ZSBwYWdlIGJvZHkgYXJlYSBuaWNlbHkuKSBUaiBUKiAoQ29udGFjdDogY2xhdWRlQG1pa2VwZW56" +
+        "LmRldiAgIFJlZjogUFJFVklFVy1SRVBSTykgVGogVCogRVQKZW5kc3RyZWFtCmVuZG9iago1IDAg" +
+        "b2JqCjw8IC9UeXBlIC9Gb250IC9TdWJ0eXBlIC9UeXBlMSAvQmFzZUZvbnQgL0hlbHZldGljYSA+" +
+        "PgplbmRvYmoKeHJlZgowIDYKMDAwMDAwMDAwMCA2NTUzNSBmIAowMDAwMDAwMDA5IDAwMDAwIG4g" +
+        "CjAwMDAwMDAwNTggMDAwMDAgbiAKMDAwMDAwMDExNSAwMDAwMCBuIAowMDAwMDAwMjQxIDAwMDAw" +
+        "IG4gCjAwMDAwMDA2MjMgMDAwMDAgbiAKdHJhaWxlcgo8PCAvU2l6ZSA2IC9Sb290IDEgMCBSID4+" +
+        "CnN0YXJ0eHJlZgo2OTMKJSVFT0Y="
+)


### PR DESCRIPTION
## The bug

`openPdfDocument` frees the native buffer twice when PDFium refuses to open the bytes — once in the `h == 0L` branch, then again in the enclosing `catch`, which the `error(...)` on the very next line always reaches:

```kotlin
val bufferAddr = PdfiumBridge.nAllocBuffer(bytes)
try {
    …
    if (h == 0L) {
        for (j in 0 until i) PdfiumBridge.nCloseDocument(handles[j])
        PdfiumBridge.nFreeBuffer(bufferAddr)   // free #1
        error("PDFium refused to open document (…)")
    }
    …
} catch (t: Throwable) {
    PdfiumBridge.nFreeBuffer(bufferAddr)       // free #2 — same address
    throw t
}
```

Any bytes PDFium rejects hit it: a 401/404 HTML body served in place of the file, the wrong variant of an attachment, a corrupt or truncated download. The app doesn't get an exception — the process dies.

Android:

```
pid: 12746, tid: 12918, name: pdfium-shared  >>> com.example.app <<<
signal 6 (SIGABRT), code -1 (SI_QUEUE), fault addr --------
Abort message: 'Scudo ERROR: invalid chunk state when deallocating address 0x20000778eedb3c0'
  #05 scudo::Allocator<scudo::AndroidNormalConfig, …>::deallocate(void*, …)
  #06 art_quick_generic_jni_trampoline
  #08 dev.nucleusframework.pdfium.PdfDocument_androidKt$openPdfDocument$2.invokeSuspend
```

Desktop/JVM is affected identically (`PdfDocument.jvm.kt` has the same shape) and exits `134`.

This isn't defensible from the caller's side: `PdfReaderState.open` already wraps the call in `catch (Throwable)`, but the double free happens below the JNI boundary, so there is nothing to catch. Validating bytes before calling is only a partial workaround — it can't cover encrypted or subtly corrupt PDFs that PDFium alone can decide on.

## The fix

Drop the inner `nFreeBuffer`; the `catch` already owns the buffer. Document handles opened before the failure are still closed in the branch, unchanged.

`androidMain` + `jvmMain` only — `iosMain` pins/unpins the `ByteArray` and `webMain` transfers an `ArrayBuffer`, so neither has a second free.

## Test

Adds `pdfium/src/jvmTest/` — the first test source set in the repo, so `:pdfium:check` (already run by Pre Merge Checks, no workflow change needed) now covers the JNI open path.

- `refusedBytesThrowInsteadOfAbortingTheProcess` — on the parent commit this does not fail, it takes the test JVM down (`finished with non-zero exit value 134 … SIGABRT`). Reaching the assertion at all is the signal.
- `aValidDocumentStillOpens` — keeps the success path's single free exercised.

Verified both directions locally on `darwin-aarch64`:

| | `:pdfium:jvmTest` |
|---|---|
| with the fix | `BUILD SUCCESSFUL` |
| fix reverted, test kept | `BUILD FAILED` — `Gradle Test Executor 2 finished with non-zero exit value 134` |

One line of wiring: `jvmTest.dependencies { implementation(libs.kotlin.test) }` (`libs.kotlin.test` was already in the catalog).

The four `configureCMakeDebug[<abi>]` tasks fail on my machine for want of an NDK/CMake toolchain, unrelated to this change; CI has them.